### PR TITLE
Adds basic Content-Security-Policy header

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -9,6 +9,7 @@ algolia:
 <!DOCTYPE html>
 <html {% if page.direction == "rtl" %}dir="rtl" {% endif %}lang="{{ page.lang | default: "en" }}">
   <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src https: ; frame-ancestors 'self'">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     {% if page.title -%}
       <title>{{ page.title }} — {{ site.title }}</title>


### PR DESCRIPTION
This should adequately cover the basic CSP use case requiring https for all assets and disallow framing except within our own site.

Possible extensions include limiting loading to just self and cdn.jsdelivr.net with fetch of algolia.net, too. We'd probably also need images from avatars2.githubusercontent.com for blog posts.

Fixes #972